### PR TITLE
Add method for encoding a public key as in SEC1

### DIFF
--- a/fastecdsa/curve.py
+++ b/fastecdsa/curve.py
@@ -1,4 +1,3 @@
-from fastecdsa import curvemath
 
 
 class Curve:
@@ -74,6 +73,17 @@ class Curve:
         left = y * y
         right = (x * x * x) + (self.a * x) + self.b
         return (left - right) % self.p == 0
+
+    def evaluate(self, x):
+        """ Evaluate the elliptic curve polynomial at 'x'
+        
+        Args:
+            x (int): The position to evaluate the polynomial at
+
+        Returns:
+            int: the value of (x^3 + ax + b) mod p
+        """
+        return (x ** 3 + self.a * x + self.b) % self.p
 
     @property
     def G(self):

--- a/fastecdsa/curve.py
+++ b/fastecdsa/curve.py
@@ -76,7 +76,7 @@ class Curve:
 
     def evaluate(self, x):
         """ Evaluate the elliptic curve polynomial at 'x'
-        
+
         Args:
             x (int): The position to evaluate the polynomial at
 

--- a/fastecdsa/point.py
+++ b/fastecdsa/point.py
@@ -62,12 +62,12 @@ class Point:
         """
         bytelen = _int_bytelen(curve.q)
         if key.startswith(b'\x04'):        # uncompressed key
-            if len(key) != bytelen*2+1:
-                raise InvalidSEC1PublicKey('An uncompressed public key must be %d bytes long' % (bytelen*2+1))
-            x, y = _bytes_to_int(key[1:bytelen+1]), _bytes_to_int(key[bytelen+1:])
+            if len(key) != bytelen * 2 + 1:
+                raise InvalidSEC1PublicKey('An uncompressed public key must be %d bytes long' % (bytelen * 2 + 1))
+            x, y = _bytes_to_int(key[1:bytelen + 1]), _bytes_to_int(key[bytelen + 1:])
         else:                              # compressed key
-            if len(key) != bytelen+1:
-                raise InvalidSEC1PublicKey('A compressed public key must be %d bytes long' % (bytelen+1))
+            if len(key) != bytelen + 1:
+                raise InvalidSEC1PublicKey('A compressed public key must be %d bytes long' % (bytelen + 1))
             x = _bytes_to_int(key[1:])
             root = mod_sqrt(curve.evaluate(x), curve.p)[0]
             if key.startswith(b'\x03'):    # odd root

--- a/fastecdsa/test.py
+++ b/fastecdsa/test.py
@@ -668,10 +668,10 @@ class TestEncodePublicKey(unittest.TestCase):
                                 y=0x3dad76df888abde5ed0cc5af1b83968edffcae5d70bedb24fdc18bb5f79499d0,
                                 curve=secp256k1)
         public_from_compressed = Point.decode(secp256k1,
-                                                   unhexlify(b'02e5e2c01985aafb6e2c3ad49f3db5ccc54b2e63343af405b521303d0f35835062'))
+                                              unhexlify(b'02e5e2c01985aafb6e2c3ad49f3db5ccc54b2e63343af405b521303d0f35835062'))
         public_from_uncompressed = Point.decode(secp256k1,
-                                                     unhexlify(b'04e5e2c01985aafb6e2c3ad49f3db5ccc54b2e63343af405b521303d0f3583506'
-                                                               b'23dad76df888abde5ed0cc5af1b83968edffcae5d70bedb24fdc18bb5f79499d0'))
+                                                unhexlify(b'04e5e2c01985aafb6e2c3ad49f3db5ccc54b2e63343af405b521303d0f3583506'
+                                                          b'23dad76df888abde5ed0cc5af1b83968edffcae5d70bedb24fdc18bb5f79499d0'))
         # Same values as in "test_SEC1_encode_public_key", verified using openssl
         self.assertEqual(public_from_compressed, expected_public)
         self.assertEqual(public_from_uncompressed, expected_public)
@@ -690,14 +690,14 @@ class TestEncodePublicKey(unittest.TestCase):
                               y=0x9a7d581bcf2aba680b53cedbade03be62fe95869da04a168a458f369ac6a823e,
                               curve=P256)
         public_from_compressed = Point.decode(P256,
-                                                   unhexlify(b'0212c9ddf64b0d1f1d91d9bd729abfb880079fa889d66604cc0b78c9cbc271824c'))
+                                              unhexlify(b'0212c9ddf64b0d1f1d91d9bd729abfb880079fa889d66604cc0b78c9cbc271824c'))
         self.assertEqual(public_from_compressed, expected_P256)
         # With P256, same values as in "test_SEC1_encode_public_key", verified using openssl
         expected_secp192k1 = Point(x=0xa3bec5fba6d13e51fb55bd88dd097cb9b04f827bc151d22d,
                                    y=0xf07a73819149e8d903aa983e52ab1cff38f0d381f940d361,
                                    curve=secp192k1)
         public_from_compressed = Point.decode(secp192k1,
-                                                   unhexlify(b'03a3bec5fba6d13e51fb55bd88dd097cb9b04f827bc151d22d'))
+                                              unhexlify(b'03a3bec5fba6d13e51fb55bd88dd097cb9b04f827bc151d22d'))
         self.assertEqual(public_from_compressed, expected_secp192k1)
 
 


### PR DESCRIPTION
Hi Anton, what do you think about adding something like this? It is common to encode public keys in SEC1 format as openssl does  + compressed format is useful as it takes less space. You didn't have any method for it so I added this.
I needed it in my project while implementing a proto ECIES implementation.
