### PR TITLE
[fastecdsa] ECC corner cases

### DIFF
--- a/fastecdsa/point.py
+++ b/fastecdsa/point.py
@@ -133,7 +133,6 @@ class Point:
             :class:`Point`: A point :math:`R` such that :math:`R = P * d`
         """
         validate_type(scalar, int)
-        scalar %= self.curve.q
 
         if scalar == 0:
             return self.IDENTITY_ELEMENT
@@ -149,7 +148,11 @@ class Point:
             str(self.curve.gx),
             str(self.curve.gy)
         )
-        return Point(int(x), int(y), self.curve)
+        x = int(x)
+        y = int(y)
+        if x == 0 and y == 0:
+            return self.IDENTITY_ELEMENT
+        return Point(x, y, self.curve)
 
     def __rmul__(self, scalar: int):
         """Multiply a :class:`Point` on an elliptic curve by an integer.

--- a/src/curveMath.c
+++ b/src/curveMath.c
@@ -39,7 +39,13 @@ void pointZZ_pDouble(PointZZ_p * rop, const PointZZ_p * op, const CurveZZ_p * cu
     mpz_mul_ui(numer, numer, 3);
     mpz_add(numer, numer, curve->a);
     mpz_mul_ui(denom, op->y, 2);
-    mpz_invert(denom, denom, curve->p);  // TODO check status
+
+    // handle 2P = identity case
+    if (mpz_invert(denom, denom, curve->p) == 0) {
+        mpz_clears(numer, denom, lambda, NULL);
+        return pointZZ_pSetToIdentityElement(rop);
+    }
+
     mpz_mul(lambda, numer, denom);
     mpz_mod(lambda, lambda, curve->p);
 


### PR DESCRIPTION
* Ensure 2Q = inf for ord(Q)=2 points
* Better inf handling post scalar multiplication
* Unit tests

Co-authored-by: Luis Rivera-Zamarripa <luis.riverazamarripa@tuni.fi>
Co-authored-by: Jesús-Javier Chi-Domínguez <jesus.chidominguez@tuni.fi>

Tagging @luinxz and @JJChiDguez for review.

This PR solves 2 defects:
1. You cannot always reduce scalars modulo `curve.q`. Only if the input point has order `curve.q`.
2. Point doubling did not handle the ord(Q) = 2 case correctly.

Edit: the golden `subgroup` values in the tests are from `sagemath`.