### PR TITLE
Avoid leaking nonce in _ecdsa_sign()

### DIFF
--- a/src/_ecdsa.c
+++ b/src/_ecdsa.c
@@ -84,7 +84,7 @@ static PyObject * _ecdsa_sign(PyObject *self, PyObject *args) {
 
     char * resultR = mpz_get_str(NULL, 10, sig.r);
     char * resultS = mpz_get_str(NULL, 10, sig.s);
-    mpz_clears(sig.r, sig.s, privKey, NULL);
+    mpz_clears(sig.r, sig.s, privKey, nonce, NULL);
 
     PyObject * ret = Py_BuildValue("ss", resultR, resultS);
     free(resultR);


### PR DESCRIPTION
The nonce was allocated by mpz_set_str(), so must be freed
by mpz_clear(). This makes the test by @EggPool in #6 run
in constant memory.