### PR TITLE
Update docstring for sign with Return value

### DIFF
--- a/fastecdsa/ecdsa.py
+++ b/fastecdsa/ecdsa.py
@@ -28,6 +28,9 @@ def sign(msg: MsgTypes, d: int, curve: Curve = P256, hashfunc=sha256, prehashed:
         |  curve (fastecdsa.curve.Curve): The curve to be used to sign the message.
         |  hashfunc (_hashlib.HASH): The hash function used to compress the message.
         |  prehashed (bool): The message being passed has already been hashed by :code:`hashfunc`.
+        
+    Returns:
+        int, int: The signature (r, s) as a tuple.
     """
     # generate a deterministic nonce per RFC6979
     rfc6979 = RFC6979(msg, d, curve.q, hashfunc, prehashed=prehashed)


### PR DESCRIPTION
Hi, There is no return value specified in the documentation for the fastecdsa.ecdsa.sign function. Can a return value be added to the docstring? Thank you. 