### PR TITLE
Avoid illegal escape charaters in docstrings

### DIFF
--- a/fastecdsa/curve.py
+++ b/fastecdsa/curve.py
@@ -75,7 +75,7 @@ class Curve:
         return (left - right) % self.p == 0
 
     def evaluate(self, x: int) -> int:
-        """ Evaluate the elliptic curve polynomial at 'x'
+        r""" Evaluate the elliptic curve polynomial at 'x'
 
         Args:
             x (int): The position to evaluate the polynomial at

--- a/fastecdsa/curve.py
+++ b/fastecdsa/curve.py
@@ -1,5 +1,5 @@
 class Curve:
-    """Representation of an elliptic curve.
+    r"""Representation of an elliptic curve.
 
     Defines a group for  the arithmetic operations of point addition and scalar multiplication.
     Currently only curves defined via the equation :math:`y^2 \equiv x^3 + ax + b \pmod{p}` are
@@ -16,7 +16,7 @@ class Curve:
     _oid_lookup = {}  # a lookup table for getting curve instances by their object identifier
 
     def __init__(self, name: str, p: int, a: int, b: int, q: int, gx: int, gy: int, oid: bytes = None):
-        """Initialize the parameters of an elliptic curve.
+        r"""Initialize the parameters of an elliptic curve.
 
         WARNING: Do not generate your own parameters unless you know what you are doing or you could
         generate a curve severely less secure than you think. Even then, consider using a
@@ -56,7 +56,7 @@ class Curve:
         return cls._oid_lookup.get(oid, None)
 
     def is_point_on_curve(self, point: (int, int)) -> bool:
-        """ Check if a point lies on this curve.
+        r""" Check if a point lies on this curve.
 
         The check is done by evaluating the curve equation :math:`y^2 \equiv x^3 + ax + b \pmod{p}`
         at the given point :math:`(x,y)` with this curve's domain parameters :math:`(a, b, p)`. If

--- a/fastecdsa/point.py
+++ b/fastecdsa/point.py
@@ -19,7 +19,7 @@ class Point:
     """
 
     def __init__(self, x: int, y: int, curve=P256):
-        """Initialize a point on an elliptic curve.
+        r"""Initialize a point on an elliptic curve.
 
         The x and y parameters must satisfy the equation :math:`y^2 \equiv x^3 + ax + b \pmod{p}`,
         where a, b, and p are attributes of the curve parameter.
@@ -128,7 +128,7 @@ class Point:
         return self.__add__(negative)
 
     def __mul__(self, scalar: int):
-        """Multiply a :class:`Point` on an elliptic curve by an integer.
+        r"""Multiply a :class:`Point` on an elliptic curve by an integer.
 
         Args:
             | self (:class:`Point`): a point :math:`P` on the curve
@@ -161,7 +161,7 @@ class Point:
         return Point(x, y, self.curve) if scalar > 0 else -Point(x, y, self.curve)
 
     def __rmul__(self, scalar: int):
-        """Multiply a :class:`Point` on an elliptic curve by an integer.
+        r"""Multiply a :class:`Point` on an elliptic curve by an integer.
 
         Args:
             | self (:class:`Point`): a point :math:`P` on the curve

--- a/fastecdsa/util.py
+++ b/fastecdsa/util.py
@@ -110,7 +110,7 @@ def _tonelli_shanks(n: int, p: int) -> (int, int):
 
 
 def mod_sqrt(a: int, p: int) -> (int, int):
-    """Compute the square root of :math:`a \pmod{p}`
+    r"""Compute the square root of :math:`a \pmod{p}`
 
     In other words, find a value :math:`x` such that :math:`x^2 \equiv a \pmod{p}`.
 

--- a/fastecdsa/util.py
+++ b/fastecdsa/util.py
@@ -88,7 +88,7 @@ class RFC6979:
 
 
 def _tonelli_shanks(n: int, p: int) -> (int, int):
-    """A generic algorithm for computng modular square roots."""
+    """A generic algorithm for computing modular square roots."""
     Q, S = p - 1, 0
     while Q % 2 == 0:
         Q, S = Q // 2, S + 1


### PR DESCRIPTION
Ran into deprecation warnings while running tests in my own project concerning escape characters in the docstrings for a number of types / functions in fastecdsa. These deprecation warnings will turn to syntax warnings in Python 3.12 and will be syntax *errors* further down the line:

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3.12/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3.12/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3.12/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence), use raw strings for regular expression: re.compile(r"\d+\.\d+"). In a future Python version, [SyntaxError](https://docs.python.org/3.12/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3.12/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)
> 
> *(see ["Other Language Changes"](https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes) on Python 3.12's "What's New" page)*

The easiest fix for this was to mark the offending docstrings as raw strings. Alternatively, I could turn the offending escape characters into doubly escaped ones (e.g. `\equiv` into `\\equiv`) if the maintainers would prefer that solution.