### PR TITLE
fixed urlopen giving error 403 in tests by adding User-Agent

### DIFF
--- a/fastecdsa/tests/test_rfc6979_ecdsa.py
+++ b/fastecdsa/tests/test_rfc6979_ecdsa.py
@@ -1,6 +1,6 @@
 from hashlib import sha1, sha224, sha256, sha384, sha512
 from re import findall, DOTALL
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 from unittest import TestCase
 
 from ..curve import P192, P224, P256, P384, P521
@@ -11,7 +11,7 @@ from ..util import RFC6979
 class TestRFC6979ECDSA(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.rfc6979_text = urlopen('https://tools.ietf.org/rfc/rfc6979.txt').read().decode()
+        cls.rfc6979_text = urlopen(Request('https://tools.ietf.org/rfc/rfc6979.txt', headers={'User-Agent': 'python'})).read().decode()
         cls.hash_lookup = {
             '1': sha1,
             '224': sha224,

--- a/fastecdsa/tests/test_whycheproof_vectors.py
+++ b/fastecdsa/tests/test_whycheproof_vectors.py
@@ -3,7 +3,7 @@ from json import JSONDecodeError, loads
 from sys import version_info
 from unittest import SkipTest, TestCase, skipIf
 from urllib.error import URLError
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 
 from fastecdsa.curve import (
     P224, P256, P384, P521,
@@ -25,7 +25,7 @@ class TestWycheproofEcdsaVerify(TestCase):
     @staticmethod
     def _get_tests(url):
         try:
-            test_raw = urlopen(url).read()
+            test_raw = urlopen(Request(url, headers={'User-Agent': 'python'})).read()
             test_json = loads(test_raw)
             return test_json["testGroups"]
         except (JSONDecodeError, URLError) as error:


### PR DESCRIPTION
test_rfc6979_ecdsa fails because "https://tools.ietf.org/rfc/rfc6979.txt" somehow returns error 403 without an User-Agent, so I propose to add user-agents to all request.