### PR TITLE
prevented gen_private_key from generating invalid private keys

### DIFF
--- a/fastecdsa/keys.py
+++ b/fastecdsa/keys.py
@@ -58,7 +58,7 @@ def gen_private_key(curve: Curve, randfunc: Callable[[Any], bytes] = urandom) ->
     rand >>= extra_bits
 
     # no modding by group order or we'll introduce biases
-    while rand >= curve.q:
+    while rand < 1 or rand >= curve.q:
         rand = int.from_bytes(randfunc(order_bytes), "big")
         rand >>= extra_bits
 

--- a/tests/test_keygen.py
+++ b/tests/test_keygen.py
@@ -5,22 +5,20 @@ from fastecdsa.keys import gen_private_key
 
 
 class TestKeygen(TestCase):
-    def test_gen_private_key(self):
+    def test_gen_private_key(self) -> None:
         class FakeCurve(Curve):
-            def __init__(self, q):
+            def __init__(self, q: int) -> None:
                 super().__init__("FakeCurve", 0, 0, 0, q, 0, 0)
 
         class FakeRandom:
-            def __init__(self, values=b"\x00"):
+            def __init__(self, values: bytes = b"\x01") -> None:
                 self.values = values
                 self.pos = 0
 
-            def __call__(self, nb):
+            def __call__(self, nb: int) -> bytes:
                 result = self.values[self.pos : self.pos + nb]
                 self.pos += nb
                 return result
-
-        self.assertEqual(gen_private_key(FakeCurve(2), randfunc=FakeRandom(b"\x00")), 0)
 
         # 1 byte / 6 bits shaved off + the first try is lower than the order
         self.assertEqual(gen_private_key(FakeCurve(2), randfunc=FakeRandom(b"\x40")), 1)
@@ -28,9 +26,6 @@ class TestKeygen(TestCase):
         # 1 byte / 6 bits shaved off + the first try is higher than the order
         self.assertEqual(
             gen_private_key(FakeCurve(2), randfunc=FakeRandom(b"\xc0\x40")), 1
-        )
-        self.assertEqual(
-            gen_private_key(FakeCurve(2), randfunc=FakeRandom(b"\xc0\x00")), 0
         )
 
         # 2 byte / 3 are shaved off, the first try is lower than the order.


### PR DESCRIPTION
This is in accordance with the gen_private_key docstring.

Note that 0 is an invalid private key, per "Section 3.2.1 of Standards for Efficient Cryptography 1 (SEC 1)"

also removed out-of-bounds tests and resolved mypy pre-commit hook errors by adding type annotations